### PR TITLE
use local activity and fix input type bug

### DIFF
--- a/workflows/ssn_trace.go
+++ b/workflows/ssn_trace.go
@@ -24,11 +24,14 @@ type SSNTraceWorkflowResult struct {
 func SSNTrace(ctx workflow.Context, input *SSNTraceWorkflowInput) (*SSNTraceWorkflowResult, error) {
 	var result activities.SSNTraceResult
 
-	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	ctx = workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 		StartToCloseTimeout: time.Minute,
 	})
 
-	f := workflow.ExecuteActivity(ctx, a.SSNTrace, SSNTraceWorkflowInput(*input))
+	f := workflow.ExecuteLocalActivity(ctx, a.SSNTrace, &activities.SSNTraceInput{
+		FullName: input.FullName,
+		SSN:      input.SSN,
+	})
 
 	err := f.Get(ctx, &result)
 	r := SSNTraceWorkflowResult(result)


### PR DESCRIPTION
## What was changed
Use LocalActivity for SSNTrace activity invocation to demonstration.


## Why?
To illustrate how LocalActivities appear in the history. Also, there was a bug in the input type being used to invoke it anyways.
